### PR TITLE
Update persist docs tests for new wiki format

### DIFF
--- a/tests/functional/adapter/dremio_specific/test_persist_docs.py
+++ b/tests/functional/adapter/dremio_specific/test_persist_docs.py
@@ -324,7 +324,10 @@ class TestPersistDocs(BasePersistDocs):
         self._assert_view_wikis_and_tags_delete(deleted_wiki, deleted_tags, tags["version"])
 
     def _assert_table_wikis_and_tags(self, wiki, tags):
-        expected_wiki = """Table model description "with double quotes"
+        expected_wiki = """# table_model
+
+## Description
+Table model description "with double quotes"
 and with 'single  quotes' as welll as other;
 '''abc123'''
 reserved -- characters
@@ -332,13 +335,36 @@ reserved -- characters
 --
 /* comment */
 Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
-"""
+
+
+## Columns
+
+| Column | Data Type | Description |
+| --- | --- | --- |
+| id | N/A | id Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+80% of statistics are made up on the spot
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting |
+| name | N/A | Some stuff here and then a call to
+{{ doc('my_fun_doc')}} |
+
+## Tags
+- test_tag1
+- test_tag2
+- test_tag3"""
         expected_tags = ["test_tag1", "test_tag2", "test_tag3"]
         assert wiki.get("text") == expected_wiki and wiki.get("version") == 0
         assert tags.get("tags") == expected_tags
 
     def _assert_view_wikis_and_tags(self, wiki, tags):
-        expected_wiki = """View model description "with double quotes"
+        expected_wiki = """# view_model
+
+## Description
+View model description "with double quotes"
 and with 'single  quotes' as welll as other;
 '''abc123'''
 reserved -- characters
@@ -346,17 +372,67 @@ reserved -- characters
 --
 /* comment */
 Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
-"""
+
+
+## Columns
+
+| Column | Data Type | Description |
+| --- | --- | --- |
+| id | N/A | id Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+80% of statistics are made up on the spot
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting |
+
+## Tags
+- test_tag"""
         expected_tags = ["test_tag"]
         assert wiki.get("text") == expected_wiki and wiki.get("version") == 0
         assert tags.get("tags") == expected_tags
 
     def _assert_view_wikis_and_tags_update(self, wiki, tags, previous_tag_version):
-        expected_wiki = "Updated view description!"
-        expected_tags = ["test_tag","new_tag"]
+        expected_wiki = """# view_model
+
+## Description
+Updated view description!
+
+## Columns
+
+| Column | Data Type | Description |
+| --- | --- | --- |
+| id | N/A | id Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+80% of statistics are made up on the spot
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting |
+
+## Tags
+- test_tag
+- new_tag"""
+        expected_tags = ["test_tag", "new_tag"]
         assert wiki.get("text") == expected_wiki and wiki.get("version") == 1
         assert tags.get("tags") == expected_tags and tags.get("version") != previous_tag_version
 
     def _assert_view_wikis_and_tags_delete(self, wiki, tags, previous_tag_version):
-        assert wiki.get("text") == "" and wiki.get("version") == 2
+        expected_wiki = """# view_model
+
+## Columns
+
+| Column | Data Type | Description |
+| --- | --- | --- |
+| id | N/A | id Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+80% of statistics are made up on the spot
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting |"""
+        assert wiki.get("text") == expected_wiki and wiki.get("version") == 2
         assert tags.get("tags") == [] and tags.get("version") != previous_tag_version


### PR DESCRIPTION
## Summary
- update the persist docs tests to expect markdown formatted wiki content

## Testing
- `pytest -k persist_docs -q` *(fails: ModuleNotFoundError: No module named 'build')*

------
https://chatgpt.com/codex/tasks/task_e_687e9e817a18832ea3f4a97c501ba881